### PR TITLE
Remove unstable feature; remove unsafe; 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ rust: nightly
 matrix:
   fast_finish: true
   include:
-  - env: TARGET=x86_64-unknown-linux-gnu
-  - env: STABLE
-    rust: 1.26.0
+  - name: "Nightly - x86_64-unknown-linux-gnu"
+    env: TARGET=x86_64-unknown-linux-gnu
+  - name: "Stable - x86_64-unknown-linux-gnu"
+    rust: 1.35.0
     script:
       - cargo test
       - cargo test --release
-  - env: CHECK_ASM
+  - name: "Check Assembly"
     os: osx
     osx_image: xcode9.2
     script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitintr"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["gnzlbg <gonzalobg88@gmail.com>"]
 description = "Portable Bit Manipulation Intrinsics."
 documentation = "https://docs.rs/bitintr"
@@ -10,6 +10,8 @@ readme = "readme.md"
 keywords = ["portable", "bit", "manipulation", "intrinsics"]
 license = "MIT"
 categories = ["algorithms", "hardware-support", "no-std"]
+build = "build.rs"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "gnzlbg/bitintr", branch = "master" }
@@ -17,16 +19,12 @@ is-it-maintained-issue-resolution = { repository = "gnzlbg/bitintr" }
 is-it-maintained-open-issues = { repository = "gnzlbg/bitintr" }
 maintenance = { status = "experimental" }
 
-[features]
-unstable = []
-
 [profile.test]
 opt-level = 0
 debug = true
 lto = false
 debug-assertions = true
 codegen-units = 1
-panic = 'unwind'
 
 [profile.bench]
 opt-level = 3
@@ -35,7 +33,6 @@ rpath = false
 lto = true
 debug-assertions = false
 codegen-units = 1
-panic = 'abort'
 
 [[bench]]
 name = "rbit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ codegen-units = 1
 [[bench]]
 name = "rbit"
 harness = false
+
+# Required to run the benchmarks
+#[dev-dependencies]
+#bencher = "0.1"

--- a/asm/x86_bmi2_mulx.asm
+++ b/asm/x86_bmi2_mulx.asm
@@ -11,7 +11,7 @@ _umulx_u32:
 _umulx_u64:
   pushq	%rbp
 	movq	%rsp, %rbp
-	movq	%rsi, %rdx
-	mulxq	%rdi, %rax, %rdx
+	movq	%rsi, %rax
+	mulq	%rdi
 	popq	%rbp
 	retq

--- a/benches/rbit.rs
+++ b/benches/rbit.rs
@@ -28,14 +28,13 @@ fn rbit_u8_4_impl(x: u8) -> u8 {
 
 fn rbit_u8_7_impl(x: u8) -> u8 {
     ((((((x as u32) * 0x0802u32) & 0x22110u32)
-        | (((x as u32) * 0x8020u32) & 0x88440u32)) * 0x10101u32) >> 16)
-        as u8
+        | (((x as u32) * 0x8020u32) & 0x88440u32))
+        * 0x10101u32)
+        >> 16) as u8
 }
 
 fn rbit_u8_bitintr(bench: &mut Bencher) {
-    u8_runner(bench, |x| {
-        bencher::black_box(bitintr::arm::v7::rbit(x))
-    })
+    u8_runner(bench, |x| bencher::black_box(bitintr::arm::v7::rbit(x)))
 }
 
 fn rbit_u8_3(bench: &mut Bencher) {
@@ -50,11 +49,5 @@ fn rbit_u8_7(bench: &mut Bencher) {
     u8_runner(bench, |x| bencher::black_box(rbit_u8_7_impl(x)))
 }
 
-benchmark_group!(
-    rbit,
-    rbit_u8_bitintr,
-    rbit_u8_3,
-    rbit_u8_4,
-    rbit_u8_7
-);
+benchmark_group!(rbit, rbit_u8_bitintr, rbit_u8_3, rbit_u8_4, rbit_u8_7);
 benchmark_main!(rbit);

--- a/benches/rbit.rs
+++ b/benches/rbit.rs
@@ -1,18 +1,14 @@
 #[macro_use]
 extern crate bencher;
-
-extern crate bitintr;
-
 use bencher::Bencher;
 
+extern crate bitintr;
+use crate::bitintr::Rbit;
+
 fn u8_runner<F: Fn(u8) -> u8>(bench: &mut Bencher, f: F) {
-    let mut vs: [u8; std::u8::MAX as usize] = [0; std::u8::MAX as usize];
-    for i in 0..u8::max_value() {
-        vs[i as usize] = i;
-    }
     bench.iter(|| {
-        for v in &mut vs.iter_mut() {
-            *v = bencher::black_box(f(bencher::black_box(*v)));
+        for v in 0..=u8::max_value() {
+            bencher::black_box(f(bencher::black_box(v)));
         }
     })
 }
@@ -34,19 +30,19 @@ fn rbit_u8_7_impl(x: u8) -> u8 {
 }
 
 fn rbit_u8_bitintr(bench: &mut Bencher) {
-    u8_runner(bench, |x| bencher::black_box(bitintr::arm::v7::rbit(x)))
+    u8_runner(bench, |x| x.rbit())
 }
 
 fn rbit_u8_3(bench: &mut Bencher) {
-    u8_runner(bench, |x| bencher::black_box(rbit_u8_3_impl(x)))
+    u8_runner(bench, |x| rbit_u8_3_impl(x))
 }
 
 fn rbit_u8_4(bench: &mut Bencher) {
-    u8_runner(bench, |x| bencher::black_box(rbit_u8_4_impl(x)))
+    u8_runner(bench, |x| rbit_u8_4_impl(x))
 }
 
 fn rbit_u8_7(bench: &mut Bencher) {
-    u8_runner(bench, |x| bencher::black_box(rbit_u8_7_impl(x)))
+    u8_runner(bench, |x| rbit_u8_7_impl(x))
 }
 
 benchmark_group!(rbit, rbit_u8_bitintr, rbit_u8_3, rbit_u8_4, rbit_u8_7);

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,23 @@
+fn nightly_rustc() -> bool {
+    fn op() -> Option<bool> {
+        use std::{env, process, str};
+        let rustc = env::var_os("RUSTC")?;
+        let output = process::Command::new(rustc)
+            .arg("--version")
+            .output()
+            .ok()?;
+        let version = str::from_utf8(&output.stdout).ok()?;
+        Some(version.contains("nightly"))
+    }
+    if let Some(true) = op() {
+        true
+    } else {
+        false
+    }
+}
+
+fn main() {
+    if nightly_rustc() {
+        println!("cargo:rustc-cfg=bitintr_nightly");
+    }
+}

--- a/check_asm.py
+++ b/check_asm.py
@@ -54,14 +54,14 @@ def compile_file(file):
     if verbose:
         print "Checking: " + str(file) + "..."
 
-    cargo_args = 'cargo rustc --verbose --release --features unstable -- -C panic=abort -C codegen-units=1 -C lto=fat '
+    cargo_args = 'cargo rustc --verbose --release -- -C panic=abort -C codegen-units=1 -C lto=fat --cfg=\'bitintr_nightly\' '
     if file.feature:
         cargo_args = cargo_args + '-C target-feature=+{}'.format(file.feature)
     if file.arch == 'armv7' or file.arch == 'armv8':
         cargo_args = cargo_args + '--target={}'.format(arm_triplet(file.arch))
     call(str(cargo_args))
 
-    rustc_args = 'rustc --verbose -C opt-level=3 -C codegen-units=1 -C lto=fat -C panic="abort" --cfg \'feature="unstable"\' --extern bitintr=target/release/libbitintr.rlib --crate-type lib';
+    rustc_args = 'rustc --verbose -C opt-level=3 -C codegen-units=1 -C lto=fat -C panic="abort" --extern bitintr=target/release/libbitintr.rlib --crate-type lib';
     if file.feature:
         rustc_args = rustc_args + ' -C target-feature=+{}'.format(file.feature)
     if file.arch == 'armv7' or file.arch == 'armv8':

--- a/readme.md
+++ b/readme.md
@@ -4,18 +4,10 @@
 
 > `0b0000_0010_1001_1010`
 
-This library exposes _safe_ and __portable_ low-level bit manipulation
-instruction set architectures. It is `#![no_std]` but requires the
-`core::{intrinsics, arch}` components when compiled with nightly rust.
+This `#![no_std]` library exposes _safe_ and _portable_ low-level bit manipulation
+instruction set architectures. The Minimum Supported Rust Version is 1.36.0.
 
 For higher-level bitwise manipulations check the [bitwise][bitwise_link] crate.
-
-This library compiles on `stable` Rust, but provides an `unstable` crate feature that
-makes uses of the following nightly features:
-
-* [`cfg_target_feature`][cfg_target_feature] for target-feature dependent behavior,
-* `stdsimd`: for `core::arch` intrinsics,
-* `core_intrinsics`: for `core::intrinsics`.
 
 The intrinsics are exposed via traits named after their CPU instruction. These
 traits are implemented for all integer types _except_ `u128/i128`.
@@ -72,5 +64,4 @@ any additional terms or conditions.
 [armv6_link]: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0419c/index.html
 [armv7_link]: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0403e.b/index.html
 [armv8_link]: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0487a.k_10775/index.html
-[cfg_target_feature]: https://github.com/rust-lang/rust/issues/29717
 [bitwise_link]: https://github.com/gnzlbg/bitwise

--- a/src/blcmsk.rs
+++ b/src/blcmsk.rs
@@ -2,7 +2,8 @@
 
 /// Mask from lowest clear bit.
 pub trait Blcmsk {
-    /// Sets the least significant bit of `self` and clears all bits above that bit.
+    /// Sets the least significant bit of `self` and clears all bits above that
+    /// bit.
     ///
     /// If there is no zero bit in `self`, it sets all the bits.
     ///

--- a/src/blsmsk.rs
+++ b/src/blsmsk.rs
@@ -38,13 +38,4 @@ macro_rules! impl_blsmsk {
     };
 }
 
-impl_all!(
-    impl_blsmsk: u8,
-    u16,
-    u32,
-    u64,
-    i8,
-    i16,
-    i32,
-    i64
-);
+impl_all!(impl_blsmsk: u8, u16, u32, u64, i8, i16, i32, i64);

--- a/src/bzhi.rs
+++ b/src/bzhi.rs
@@ -28,62 +28,69 @@ pub trait Bzhi {
     fn bzhi(self, bit_position: u32) -> Self;
 }
 
-macro_rules! empty {
-    ($_x:ident, $_y:ident, $_i:ident) => {};
-}
-
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-macro_rules! bzhi_spec {
-    ($x:ident, $y:ident, $intr:ident) => {
-        #[cfg(feature = "unstable")]
-        #[cfg(
-            all(
-                any(target_arch = "x86", target_arch = "x86_64"),
-                target_feature = "bmi2"
-            )
-        )]
-        {
-            return unsafe {
-                ::mem::transmute(::arch::$intr(
-                    ::mem::transmute($x),
-                    $y as u32,
-                ))
-            };
+macro_rules! bzhi_impl {
+    ($ty:ty) => {
+        #[inline]
+        fn bzhi_(value: $ty, bit_position: u32) -> $ty {
+            debug_assert!(
+                bit_position < (crate::mem::size_of::<$ty>() * 8) as u32
+            );
+            value & ((1 << bit_position) - 1)
+        }
+    };
+    ($ty:ty, $intr:ident) => {
+        cfg_if! {
+            if  #[cfg(all(
+                  any(target_arch = "x86", target_arch = "x86_64"),
+                  target_feature = "bmi2"
+            ))] {
+                #[inline]
+                #[target_feature(enable = "bmi2")]
+                unsafe fn bzhi_(value: $ty, bit_position: u32) -> $ty {
+                    crate::arch::$intr(
+                        value as _,
+                        bit_position,
+                    ) as _
+                }
+            } else {
+                bzhi_impl!($ty);
+            }
         }
     };
 }
 
 macro_rules! impl_bzhi {
-    ($id:ident, $arch_bzhi:ident, $intr:ident) => {
+    ($id:ident $(,$args:ident)*) => {
         impl Bzhi for $id {
             #[inline]
-            #[allow(unreachable_code)]
+            #[allow(unused_unsafe)]
             fn bzhi(self, bit_position: u32) -> Self {
-                debug_assert!(
-                    bit_position < (::mem::size_of::<Self>() * 8) as u32
-                );
-                $arch_bzhi!(self, bit_position, $intr);
-                self & ((1 << bit_position) - 1)
+                bzhi_impl!($id $(,$args)*);
+                // UNSAFETY: this is always safe, because
+                // the unsafe `#[target_feature]` function
+                // is only generated when the feature is
+                // statically-enabled at compile-time.
+                unsafe { bzhi_(self, bit_position) }
             }
         }
-    };
-    ($id:ident) => {
-        impl_bzhi!($id, empty, empty);
     };
 }
 
 impl_all!(impl_bzhi: u8, u16, i8, i16);
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl_bzhi!(u32, bzhi_spec, _bzhi_u32);
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl_bzhi!(i32, bzhi_spec, _bzhi_u32);
-#[cfg(target_arch = "x86_64")]
-impl_bzhi!(u64, bzhi_spec, _bzhi_u64);
-#[cfg(target_arch = "x86_64")]
-impl_bzhi!(i64, bzhi_spec, _bzhi_u64);
-
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-impl_all!(impl_bzhi: u32, i32);
-#[cfg(not(target_arch = "x86_64"))]
-impl_all!(impl_bzhi: i64, u64);
+cfg_if! {
+    if #[cfg(any(target_arch = "x86", target_arch = "x86_64"))] {
+        impl_bzhi!(u32, _bzhi_u32);
+        impl_bzhi!(i32, _bzhi_u32);
+        cfg_if! {
+            if #[cfg(target_arch = "x86_64")] {
+                impl_bzhi!(u64, _bzhi_u64);
+                impl_bzhi!(i64, _bzhi_u64);
+            } else {
+                impl_all!(impl_bzhi: i64, u64);
+            }
+        }
+    } else {
+        impl_all!(impl_bzhi: u32, i32, i64, u64);
+    }
+}

--- a/src/cls.rs
+++ b/src/cls.rs
@@ -12,7 +12,8 @@ pub trait Cls {
     ///
     /// # Instructions
     ///
-    /// - [`CLS`](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0487a.k_10775/index.html):
+    /// - [`CLS`](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.
+    ///   ddi0487a.k_10775/index.html):
     ///   - Description: Count leading sign bits.
     ///   - Architecture: ARMv8.
     ///   - Registers: 32/64 bits.
@@ -30,10 +31,14 @@ pub trait Cls {
 
 macro_rules! impl_cls {
     ($id:ident, $sid:ident, $width:expr) => {
+        #[allow(clippy::use_self)]
         impl Cls for $id {
             #[inline]
             fn cls(self) -> Self {
-                $id::leading_zeros((((((self as $sid) >> ($width - 1)) as $id) ^ self) << 1) | 1) as $id
+                Self::leading_zeros(
+                    (((((self as $sid) >> ($width - 1)) as Self) ^ self) << 1)
+                        | 1,
+                ) as Self
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,18 +9,11 @@
 //! The `std::arch` intrinsics are used when the required features are enabled
 //! in the target. You might manually enable features via `-C
 //! target-feature=+...` and/or `-C target-cpu=...`.
-
-#![cfg_attr(
-    feature = "unstable", feature(cfg_target_feature, stdsimd, core_intrinsics)
-)]
 #![no_std]
+#![cfg_attr(bitintr_nightly, feature(stdsimd))]
 
 use core::{marker, mem};
 
-#[cfg(feature = "unstable")]
-use core::intrinsics;
-
-#[cfg(feature = "unstable")]
 mod arch {
     #[cfg(target_arch = "x86")]
     pub use core::arch::x86::*;
@@ -103,7 +96,6 @@ pub use self::blcs::Blcs;
 
 mod blsfill;
 pub use self::blsfill::Blsfill;
-
 
 mod t1mskc;
 pub use self::t1mskc::T1mskc;

--- a/src/lzcnt.rs
+++ b/src/lzcnt.rs
@@ -26,7 +26,8 @@ pub trait Lzcnt {
     /// - Note: This instruction is officially part of BMI1 but Intel (and
     /// AMD)   CPUs advertise it as being part of ABM.
     ///
-    /// - [`CLZ`](https://www.pjrc.com/teensy/beta/DDI0403D_arm_architecture_v7m_reference_manual.pdf):
+    /// - [`CLZ`](https://www.pjrc.com/teensy/beta/
+    ///   DDI0403D_arm_architecture_v7m_reference_manual.pdf):
     ///   - Description: Count Leading Zeros.
     ///   - Architecture: ARM.
     ///   - Instruction set: v7.
@@ -47,7 +48,7 @@ macro_rules! impl_lzcnt {
         impl Lzcnt for $id {
             #[inline]
             fn lzcnt(self) -> Self {
-                self.leading_zeros() as $id
+                self.leading_zeros() as Self
             }
 
             #[inline]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,3 +7,57 @@ macro_rules! impl_all {
         )*
     }
 }
+
+macro_rules! cfg_if {
+    // match if/else chains with a final `else`
+    ($(
+        if #[cfg($($meta:meta),*)] { $($it:item)* }
+    ) else * else {
+        $($it2:item)*
+    }) => {
+        cfg_if! {
+            @__items
+            () ;
+            $( ( ($($meta),*) ($($it)*) ), )*
+            ( () ($($it2)*) ),
+        }
+    };
+
+    // match if/else chains lacking a final `else`
+    (
+        if #[cfg($($i_met:meta),*)] { $($i_it:item)* }
+        $(
+            else if #[cfg($($e_met:meta),*)] { $($e_it:item)* }
+        )*
+    ) => {
+        cfg_if! {
+            @__items
+            () ;
+            ( ($($i_met),*) ($($i_it)*) ),
+            $( ( ($($e_met),*) ($($e_it)*) ), )*
+            ( () () ),
+        }
+    };
+
+    // Internal and recursive macro to emit all the items
+    //
+    // Collects all the negated cfgs in a list at the beginning and after the
+    // semicolon is all the remaining items
+    (@__items ($($not:meta,)*) ; ) => {};
+    (@__items ($($not:meta,)*) ; ( ($($m:meta),*) ($($it:item)*) ), $($rest:tt)*) => {
+        // Emit all items within one block, applying an approprate #[cfg]. The
+        // #[cfg] will require all `$m` matchers specified and must also negate
+        // all previous matchers.
+        cfg_if! { @__apply cfg(all($($m,)* not(any($($not),*)))), $($it)* }
+
+        // Recurse to emit all other items in `$rest`, and when we do so add all
+        // our `$m` matchers to the list of `$not` matchers as future emissions
+        // will have to negate everything we just matched as well.
+        cfg_if! { @__items ($($not,)* $($m,)*) ; $($rest)* }
+    };
+
+    // Internal macro to Apply a cfg attribute to a list of items
+    (@__apply $m:meta, $($it:item)*) => {
+        $(#[$m] $it)*
+    };
+}

--- a/src/mulx.rs
+++ b/src/mulx.rs
@@ -1,7 +1,7 @@
 //! mulx
 
 /// Unsigned multiply without affecting flags.
-pub trait Mulx: ::marker::Sized {
+pub trait Mulx: crate::marker::Sized {
     /// Unsigned multiply without affecting flags.
     ///
     /// Unsigned multiplication of `x` with `y` returning a pair `(lo, hi)`
@@ -80,34 +80,36 @@ pub trait Mulx: ::marker::Sized {
 }
 
 macro_rules! impl_umulx {
-    ($id:ident, $id_l:ident, $bit_width:expr) => {
+    ($id:ident, $id_l:ident) => {
+        #[allow(clippy::use_self)]
         impl Mulx for $id {
             #[inline]
             fn mulx(self, y: Self) -> (Self, Self) {
+                const BIT_WIDTH: $id_l =
+                    (crate::mem::size_of::<$id>() * 8) as $id_l;
                 let x = self;
                 let result: $id_l = (x as $id_l) * (y as $id_l);
-                let hi = (result >> $bit_width) as $id;
-                (result as $id, hi)
+                let hi = (result >> BIT_WIDTH) as Self;
+                (result as Self, hi)
             }
         }
     };
 }
 
-impl_umulx!(u8, u16, 8);
-impl_umulx!(u16, u32, 16);
-impl_umulx!(u32, u64, 32);
-impl_umulx!(u64, u128, 64);
+impl_umulx!(u8, u16);
+impl_umulx!(u16, u32);
+impl_umulx!(u32, u64);
+impl_umulx!(u64, u128);
 
 macro_rules! impl_smulx {
     ($id:ident, $uid:ident) => {
         impl Mulx for $id {
             #[inline]
             fn mulx(self, y: Self) -> (Self, Self) {
-                unsafe {
-                    let ux: $uid = ::mem::transmute(self);
-                    let uy: $uid = ::mem::transmute(y);
-                    ::mem::transmute(ux.mulx(uy))
-                }
+                let ux = self as $uid;
+                let uy = y as $uid;
+                let (rx, ry) = ux.mulx(uy);
+                (rx as _, ry as _)
             }
         }
     };

--- a/src/popcnt.rs
+++ b/src/popcnt.rs
@@ -36,13 +36,4 @@ macro_rules! impl_popcnt {
     };
 }
 
-impl_all!(
-    impl_popcnt: u8,
-    u16,
-    u32,
-    u64,
-    i8,
-    i16,
-    i32,
-    i64
-);
+impl_all!(impl_popcnt: u8, u16, u32, u64, i8, i16, i32, i64);

--- a/src/rev.rs
+++ b/src/rev.rs
@@ -9,7 +9,8 @@ pub trait Rev {
     ///
     /// # Instructions
     ///
-    /// - [`REV`](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0419c/index.html):
+    /// - [`REV`](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.
+    ///   ddi0419c/index.html):
     ///   - Description: Reverses the byte order in a register.
     ///   - Architecture: ARMv6, ARMv7, ARMv8.
     ///   - Registers: 32 (v6, v7)/64 (v8) bits.

--- a/src/t1mskc.rs
+++ b/src/t1mskc.rs
@@ -2,8 +2,8 @@
 
 /// Inverse mask from trailing ones
 pub trait T1mskc {
-    /// Clears all bits below the least significant zero of `self` and sets all other
-    /// bits.
+    /// Clears all bits below the least significant zero of `self` and sets all
+    /// other bits.
     ///
     /// If the least significant bit of `self` is 0, it sets all bits.
     ///
@@ -37,4 +37,3 @@ macro_rules! impl_t1mskc {
 }
 
 impl_all!(impl_t1mskc: u8, u16, u32, u64, i8, i16, i32, i64);
-

--- a/src/tzmsk.rs
+++ b/src/tzmsk.rs
@@ -2,8 +2,8 @@
 
 /// Mask from trailing zeros
 pub trait Tzmsk {
-    /// Sets all bits below the least significant one of `self` and clears all other
-    /// bits.
+    /// Sets all bits below the least significant one of `self` and clears all
+    /// other bits.
     ///
     /// If the least significant bit of `self` is 1, it returns zero.
     ///
@@ -37,4 +37,3 @@ macro_rules! impl_tzmsk {
 }
 
 impl_all!(impl_tzmsk: u8, u16, u32, u64, i8, i16, i32, i64);
-


### PR DESCRIPTION
This PR updates the Minimum Supported Rust Version to 1.36.0. 

It removes a lot of `unsafe` code, most of the nightly features, ports the crate to Rust 2018, updates the Readme, and does a version `0.3` release.

Closes #7 . 