### PR TITLE
Fix pext/pdep panic in debug mode

### DIFF
--- a/src/pdep.rs
+++ b/src/pdep.rs
@@ -43,7 +43,7 @@ macro_rules! pdep_impl {
         #[inline]
         fn pdep_(value: $ty, mut mask: $ty) -> $ty {
             let mut res = 0;
-            let mut bb = 1;
+            let mut bb: $ty = 1;
             loop {
                 if mask == 0 {
                     break;
@@ -52,7 +52,7 @@ macro_rules! pdep_impl {
                     res |= mask & mask.wrapping_neg();
                 }
                 mask &= mask - 1;
-                bb += bb;
+                bb = bb.wrapping_add(bb);
             }
             res
         }

--- a/src/pext.rs
+++ b/src/pext.rs
@@ -42,7 +42,7 @@ macro_rules! pext_impl {
         #[inline]
         fn pext_(value: $ty, mut mask: $ty) -> $ty {
             let mut res = 0;
-            let mut bb = 1;
+            let mut bb: $ty = 1;
             loop {
                 if mask == 0 {
                     break;
@@ -51,7 +51,7 @@ macro_rules! pext_impl {
                     res |= bb;
                 }
                 mask &= mask - 1;
-                bb += bb;
+                bb = bb.wrapping_add(bb);
             }
             res
         }


### PR DESCRIPTION
When compiling with the software implementation of pext/pdep in debug mode, the functions panic from integer overflow for large inputs. Example:
````
use bitintr::{Pext, Pdep};

fn main() {
    println!("{}", 0_u64.pext(u64::max_value()));
    println!("{}", 0_u64.pdep(u64::max_value()));
}
````

The overflow always happens in the last iteration of the loop, so the result is never used and is not dangerous. This PR fixes the crash by using `wrapping_add` to disable overflow checks in debug mode.